### PR TITLE
chore: Update features api endpoints

### DIFF
--- a/lib/kickplan/resource/features.ex
+++ b/lib/kickplan/resource/features.ex
@@ -12,7 +12,12 @@ defmodule Kickplan.Features do
   def resolve(key, _) when is_list(key) or is_map(key), do: resolve(nil, key)
 
   def resolve(key, params) do
-    with {:ok, resp} <- Client.post("features/#{key}", params) do
+    path =
+      ["features", key, "resolve"]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("/")
+
+    with {:ok, resp} <- Client.post(path, params) do
       {:ok, resp |> Response.into(Schema.Resolution)}
     end
   end

--- a/test/cassettes/features/resolve-all.json
+++ b/test/cassettes/features/resolve-all.json
@@ -5,7 +5,7 @@
         "with_body": "true"
       },
       "body": "{}",
-      "url": "https://demo-control.fly.dev/api/features/",
+      "url": "https://demo-control.fly.dev/api/features/resolve",
       "headers": {
         "Authorization": "***",
         "Content-Type": "application/json",
@@ -22,11 +22,11 @@
         "cache-control": "max-age=0, private, must-revalidate",
         "content-length": "308",
         "content-type": "application/json; charset=utf-8",
-        "date": "Thu, 22 Aug 2024 19:19:14 GMT",
-        "server": "Fly/5e55b43a7 (2024-08-21)",
-        "x-request-id": "F-4jJk91UgTYSXkAAAyB",
+        "date": "Mon, 26 Aug 2024 18:58:38 GMT",
+        "server": "Fly/21b3f2da (2024-08-24)",
+        "x-request-id": "F-9cWPS8oKftqV0AAA8B",
         "via": "1.1 fly.io",
-        "fly-request-id": "01J5XREQJRTKHBC3Y5CJQAPDYK-sea"
+        "fly-request-id": "01J680VX6EBS8X27Z7J6E9W1KA-sea"
       },
       "status_code": 200
     }

--- a/test/cassettes/features/resolve.json
+++ b/test/cassettes/features/resolve.json
@@ -5,7 +5,7 @@
         "with_body": "true"
       },
       "body": "{}",
-      "url": "https://demo-control.fly.dev/api/features/contact-limit",
+      "url": "https://demo-control.fly.dev/api/features/contact-limit/resolve",
       "headers": {
         "Authorization": "***",
         "Content-Type": "application/json",
@@ -22,11 +22,11 @@
         "cache-control": "max-age=0, private, must-revalidate",
         "content-length": "33",
         "content-type": "application/json; charset=utf-8",
-        "date": "Thu, 22 Aug 2024 19:43:57 GMT",
-        "server": "Fly/5e55b43a7 (2024-08-21)",
-        "x-request-id": "F-4kf6KMXpujMxwAAAyx",
+        "date": "Mon, 26 Aug 2024 18:58:39 GMT",
+        "server": "Fly/21b3f2da (2024-08-24)",
+        "x-request-id": "F-9cWQfLfHOHRrIAAA8R",
         "via": "1.1 fly.io",
-        "fly-request-id": "01J5XSVZZEBDC5XTBGR0QKYXXJ-sea"
+        "fly-request-id": "01J680VXGEBVK6BMW59K9SC91H-sea"
       },
       "status_code": 200
     }


### PR DESCRIPTION
The non-suffixed `features` and `features/:key` endpoints are deprecated and have been replaced with `features/resolve` and `features/:key/resolve` respectively.

Those endpoints will instead be used to return the actual feature(s) configuration.